### PR TITLE
Add context for catalog search to allow local export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add context for catalog search to allow local export.
+  [thomasmassmann]
 
 
 1.1 (2018-03-27)

--- a/src/collective/contentexport/browser/export.py
+++ b/src/collective/contentexport/browser/export.py
@@ -282,6 +282,10 @@ class ExportView(BrowserView):
                 'Language' in catalog.indexes():
             query['Language'] = 'all'
 
+        if 'path' not in query:
+            query['path'] = {}
+            query['path']['query'] = '/'.join(self.context.getPhysicalPath())
+
         brains = catalog(query)
         for brain in brains:
             obj = brain.getObject()
@@ -414,7 +418,11 @@ class ExportView(BrowserView):
         for fti in portal_types.listTypeInfo():
             if not IDexterityFTI.providedBy(fti):
                 continue
-            number = len(catalog(portal_type=fti.id))
+            query = {}
+            query['portal_type'] = fti.id
+            query['path'] = {}
+            query['path']['query'] = '/'.join(self.context.getPhysicalPath())
+            number = len(catalog(query))
             if number >= 1:
                 results.append({
                     'number': number,


### PR DESCRIPTION
The browser view is already registered for all content. With the additional path query we can export items in a local tree.